### PR TITLE
Saturdayの芝生が刈られることを防ぐため、庭の高さを調整

### DIFF
--- a/views/garden.erb
+++ b/views/garden.erb
@@ -2,7 +2,7 @@
   username: <a href=<%= "https://github.com/#{@garden.user_name}" %>><%= @garden.user_name %></a>
 </div>
 <div class=svg>
-  <svg width=750px height=100px dominant-baseline="central">
+  <svg width="750" height="104" dominant-baseline="central">
     <%= @garden.garden_svg %>
   </svg>
 </div>


### PR DESCRIPTION
# 発生している問題の概要
`views/garden.erb`において、
githubからfetchしてきたsvgのheightが104pxだが、その親要素としてのsvg要素のheightが100pxであるため、土曜日の芝生が刈られてしまう(4px分、見えない部分ができる)。

# 変更点概要
* 上記の問題であるsvg要素のheightを104pxに修正
* svgのwidth, height属性をダブルクォーテーションで囲うように統一
* svgのwidth, height属性の不要な"px"という記述を削除

# UIの変更
## 変更前
<img width="716" alt="2018-06-30 14 34 08" src="https://user-images.githubusercontent.com/5182986/42121885-cc66c27c-7c72-11e8-9897-93bd5e6f4567.png">

## 変更後
<img width="689" alt="2018-06-30 14 34 26" src="https://user-images.githubusercontent.com/5182986/42121886-d4b9cc08-7c72-11e8-87bc-a17eca5aa773.png">