### PR TITLE
/:id/by_yearにおいてSaturdayの芝生が刈られることを防ぐため、庭の高さを調整

### DIFF
--- a/public/css/garden.css
+++ b/public/css/garden.css
@@ -4,7 +4,8 @@
   margin-bottom: 20px;
 }
 .svg {
-  margin-top: 10px
+  margin-top: 10px;
+  dominant-baseline: central;
 }
 .boxes {
   padding: 0;

--- a/views/garden.erb
+++ b/views/garden.erb
@@ -2,9 +2,7 @@
   username: <a href=<%= "https://github.com/#{@garden.user_name}" %>><%= @garden.user_name %></a>
 </div>
 <div class=svg>
-  <svg width="750" height="104" dominant-baseline="central">
-    <%= @garden.garden_svg %>
-  </svg>
+  <%= @garden.garden_svg %>
 </div>
 
 <div>

--- a/views/gardens_by_year.erb
+++ b/views/gardens_by_year.erb
@@ -5,9 +5,7 @@
 <div class=svg>
   <% @garden.garden_svg_by_year.reverse_each do |year, svg| %>
     <h1><%= year %></h1>
-    <svg width=750px height=100px dominant-baseline="central">
-      <%= svg %>
-    </svg>
+    <%= svg %>
   <% end %>
 </div>
 


### PR DESCRIPTION
# 発生している問題の概要
[こちらのPR](https://github.com/longtime1116/github_gardener/pull/43)の修正漏れ
`views/gardens_by_year.erb`において、同様の問題が発生しているため修正。

# 変更点概要
* widthとheightの管理を不要にするため、githubからfetchしてきたsvgをラップするsvgを削除
* githubからfetchしてきたsvgをラップするsvgにstyleが当たっていたため、親要素の.svgにstyleを適用

# UIの変更
## 変更前
<img width="740" alt="2018-07-14 14 54 09" src="https://user-images.githubusercontent.com/5182986/42721488-91c4092c-8776-11e8-8f04-fc34554dc4f8.png">


## 変更後
<img width="740" alt="2018-07-14 14 54 24" src="https://user-images.githubusercontent.com/5182986/42721489-9458f76a-8776-11e8-82e2-7af2e9dbd8c7.png">
