### PR TITLE
consecutive daysとbest recordの値が異なる不具合修正

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -138,7 +138,7 @@ class Garden
   def consecutive_each(rects)
     count = 0
     rects[1..-1].each do |rect|
-      next if Date.parse(rect.attributes["data-date"].value) >= Date.today
+      next if Date.parse(rect.attributes["data-date"].value) > Date.today
       break if contribute_count_of(rect) == 0
       count += yield rect
     end


### PR DESCRIPTION
# 概要
表題の通り、consecutive daysとbest recordの値が異なる

# 原因
`app.rb`の`.consecutive_each`では、過去の庭を一つずつ計算を行なっている。
修正箇所の未来の日付をスキップ処理において、「当日以降をスキップ」としていたため、`.best_consecutive_days`との差異が発生してしまった。